### PR TITLE
Release v1.1.7 - Refactor Grid Cell Editing into Custom Hooks + Dataset Sync Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 <br><br>
 
+## 🔖 v1.1.7 - Released 2025-07-15
+
+### 🛠 Fixes
+
+* **Synchronized cell updates** between grid state and full dataset:
+
+  * Injected `__$index__` into each row of `dataReceivedRef` to track and update rows accurately.
+  * Modified `onCellChange` and `revertChanges` to reflect updates in both paginated/filtered view and the original dataset.
+
+### 🔍 Search Enhancements
+
+* Improved grid search to support:
+
+  * Multi-word queries
+  * Diacritic-insensitive matching (e.g. `café` → `cafe`)
+  * Special character handling
+  * Concatenated column search with customizable separators
+* Extracted formatting and normalization into helper utilities for reusability.
+
+### 🧱 Refactors
+
+* Extracted core cell editing logic into reusable hooks:
+
+  * `useCellRevert`
+  * `useCellCommit`
+  * `useCellChange`
+* Benefits:
+
+  * Cleaner separation of concerns
+  * Better testability and modularity
+  * Hooks include `configure` method to inject state context
+  * Extensive unit tests added for edge cases and update flows
+
+### 🎨 UI
+
+* Updated default theme background color from `#e0e0e0` to `#f5f1f1` for a softer look.
+
+<br><br>
+
 ## 🔖 v1.1.6 - Released 2025-07-12
 
 ### 🆕 New Features

--- a/__tests__/src/components/grid-edit/editable-dropdown-field.test.jsx
+++ b/__tests__/src/components/grid-edit/editable-dropdown-field.test.jsx
@@ -56,7 +56,6 @@ describe('EditableDropdownField', () => {
 
         expect(props.focusInput).toHaveBeenCalledWith(2);
         expect(props.commitChanges).toHaveBeenCalledWith(
-            props.rowIndex,
             props.editableColumns,
             props.baseRow,
             false
@@ -69,7 +68,6 @@ describe('EditableDropdownField', () => {
         fireEvent.keyDown(dropdownButton, { key: 'Tab', shiftKey: true });
         expect(baseProps.focusInput).toHaveBeenCalledWith(0);
         expect(baseProps.commitChanges).toHaveBeenCalledWith(
-            baseProps.rowIndex,
             baseProps.editableColumns,
             baseProps.baseRow,
             false

--- a/__tests__/src/components/grid-edit/editable-text-field.test.jsx
+++ b/__tests__/src/components/grid-edit/editable-text-field.test.jsx
@@ -121,7 +121,6 @@ describe('EditableTextField integration', () => {
         expect(isNavigatingRef.current).toBe(true);
         expect(focusInput).not.toHaveBeenCalled();
         expect(commitChanges).toHaveBeenCalledWith(
-            lastIndexProps.rowIndex,
             lastIndexProps.editableColumns,
             lastIndexProps.baseRow,
             true

--- a/__tests__/src/components/grid-rows.test.jsx
+++ b/__tests__/src/components/grid-rows.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 /* eslint-disable no-prototype-builtins */
 /* eslint-disable no-unused-vars */
 /* eslint-disable react/display-name */
@@ -20,7 +21,7 @@ jest.mock('./../../../src/components/grid-edit/editable-cell-fields', () => (pro
             data-testid="editable-input"
             value={props.columnValue}
             onChange={e => props.onCellChange(e, undefined, props.editableColumns?.[0]?.colName)}
-            onBlur={() => props.commitChanges(props.rowIndex, props.editableColumns, {}, true)}
+            onBlur={() => props.commitChanges(props.editableColumns, {}, true)}
         />
     );
 });
@@ -91,7 +92,7 @@ describe('GridRows', () => {
         }
         const { container } = render(<TableComponent />);
         expect(container.querySelector('tbody')?.childElementCount).toBe(0);
-    });    
+    });
 
     it('calls onRowClick when a row is clicked', () => {
         jest.useFakeTimers();
@@ -344,7 +345,7 @@ describe('More tests for GridRows Component', () => {
             </tbody></table>);
         const tbody = container.querySelector('tbody');
         expect(tbody.children.length).toBe(0);
-    });    
+    });
 });
 
 describe('GridRows component editing', () => {
@@ -432,7 +433,7 @@ describe('GridRows component editing', () => {
     });
 
     it('commitChanges clears editingCell and calls onCellUpdate', () => {
-        state.editingCell = { rowIndex: 0, columnName: 'name' };
+        state.editingCell = { rowIndex: 0, columnName: 'name', baseRowIndex: 0 };
         state.editingCellData = { name: 'Alice' };
         setState.mockClear();
 
@@ -443,6 +444,7 @@ describe('GridRows component editing', () => {
                         state={{ ...state, onCellUpdate }}
                         setState={setState}
                         computedColumnWidthsRef={{ current: columns }}
+                        dataReceivedRef={{ current: null }}
                     />
                 </tbody>
             </table>
@@ -455,7 +457,7 @@ describe('GridRows component editing', () => {
         const newState = setStateCall[0](state);
         expect(newState).toEqual(expect.objectContaining({
             editingCell: null,
-            editingCellData: null,
+            editingCellData: null
         }));
     });
 

--- a/__tests__/src/helpers/common.test.js
+++ b/__tests__/src/helpers/common.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import { capitalize, convertViewportUnitToPixels, getContainerWidthInPixels, isEqual, isNull } from './../../../src/helpers/common';
+import { capitalize, convertViewportUnitToPixels, getContainerWidthInPixels, isEqual, isNull, normalize } from './../../../src/helpers/common';
 
 describe('isNull', () => {
     it('returns true for null, undefined, NaN', () => {
@@ -165,5 +165,51 @@ describe('capitalize', () => {
         expect(capitalize({})).toBe('');
         expect(capitalize([])).toBe('');
         expect(capitalize(() => { })).toBe('');
+    });
+});
+
+describe('normalize', () => {
+    it('should normalize accented characters', () => {
+        const result = normalize('Café');
+        expect(result).toBe('cafe');
+    });
+
+    it('should convert to lowercase', () => {
+        const result = normalize('HELLO');
+        expect(result).toBe('hello');
+    });
+
+    it('should normalize a string with multiple accents', () => {
+        const result = normalize('àéîõü');
+        expect(result).toBe('aeiou');
+    });
+
+    it('should handle a mix of normal and accented characters', () => {
+        const result = normalize('JoSé ÁlVàRéz');
+        expect(result).toBe('jose alvarez');
+    });
+
+    it('should return empty string for empty input', () => {
+        expect(normalize('')).toBe('');
+    });
+
+    it('should handle numbers and symbols', () => {
+        const result = normalize('1234-+=!@#');
+        expect(result).toBe('1234-+=!@#');
+    });
+
+    it('should return undefined for undefined input', () => {
+        expect(normalize(undefined)).toBeUndefined();
+    });
+
+    it('should convert non-string input to string before processing', () => {
+        expect(normalize(123)).toBe('123');
+        expect(normalize(null)).toBe(undefined);
+        expect(normalize(true)).toBe('true');
+    });
+
+    it('should strip diacritics and normalize combined characters', () => {
+        const result = normalize('e\u0301');
+        expect(result).toBe('e');
     });
 });

--- a/__tests__/src/hooks/use-cell-change.test.js
+++ b/__tests__/src/hooks/use-cell-change.test.js
@@ -1,0 +1,199 @@
+import { act, renderHook } from '@testing-library/react';
+import { useCellChange } from '../../../src/hooks/use-cell-change';
+
+describe('useCellChange', () => {
+    let cellChangedRef;
+
+    beforeEach(() => {
+        cellChangedRef = { current: false };
+    });
+
+    const setup = () => renderHook(() => useCellChange({ cellChangedRef }));
+
+    it('should update cell value and mark cell as changed', () => {
+        const mockSetState = jest.fn();
+        const dataReceivedRef = {
+            current: [{ name: 'Alice' }, { name: 'Bob' }]
+        };
+
+        const { result } = setup();
+
+        act(() => {
+            result.current.configure({
+                editingCell: { baseRowIndex: 1 },
+                editingCellData: {},
+                rowsData: [
+                    { __$index__: 0, name: 'Alice' },
+                    { __$index__: 1, name: 'Bob' }
+                ],
+                dataReceivedRef,
+                setState: mockSetState
+            });
+
+            result.current.onCellChange({ target: { value: 'Charlie' } }, null, 'name');
+        });
+
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        const updater = mockSetState.mock.calls[0][0];
+        const resultState = updater({ editingCellData: {} });
+
+        expect(resultState.rowsData[1].name).toBe('Charlie');
+        expect(resultState.editingCellData).toEqual({ name: 'Bob' }); // original value
+        expect(dataReceivedRef.current[1].name).toBe('Charlie');
+        expect(cellChangedRef.current).toBe(true);
+    });
+
+    it('should skip if row index not found', () => {
+        const mockSetState = jest.fn();
+        const { result } = setup();
+
+        act(() => {
+            result.current.configure({
+                editingCell: { baseRowIndex: 99 },
+                editingCellData: {},
+                rowsData: [{ __$index__: 0, name: 'Alice' }],
+                setState: mockSetState
+            });
+
+            result.current.onCellChange({ target: { value: 'X' } }, null, 'name');
+        });
+
+        expect(mockSetState).not.toHaveBeenCalled();
+        expect(cellChangedRef.current).toBe(false);
+    });
+
+    it('should skip updating dataReceivedRef if not array', () => {
+        const mockSetState = jest.fn();
+
+        const { result } = setup();
+
+        act(() => {
+            result.current.configure({
+                editingCell: { baseRowIndex: 0 },
+                editingCellData: {},
+                rowsData: [{ __$index__: 0, name: 'Alice' }],
+                dataReceivedRef: { current: null },
+                setState: mockSetState
+            });
+
+            result.current.onCellChange(null, 'Zoe', 'name');
+        });
+
+        expect(mockSetState).toHaveBeenCalled();
+        expect(cellChangedRef.current).toBe(true);
+    });
+
+    it('should skip fullDataRow update if not found', () => {
+        const mockSetState = jest.fn();
+        const dataReceivedRef = {
+            current: [undefined]
+        };
+
+        const { result } = setup();
+
+        act(() => {
+            result.current.configure({
+                editingCell: { baseRowIndex: 0 },
+                editingCellData: {},
+                rowsData: [{ __$index__: 0, name: 'Alice' }],
+                dataReceivedRef,
+                setState: mockSetState
+            });
+
+            result.current.onCellChange(null, 'Zoe', 'name');
+        });
+
+        expect(mockSetState).toHaveBeenCalled();
+        expect(cellChangedRef.current).toBe(true);
+    });
+
+    it('should not overwrite editingCellData if alreadySaved is true', () => {
+        const mockSetState = jest.fn();
+
+        const { result } = setup();
+
+        act(() => {
+            result.current.configure({
+                editingCell: { baseRowIndex: 0 },
+                editingCellData: { name: 'Alice' },
+                rowsData: [{ __$index__: 0, name: 'Alice' }],
+                setState: mockSetState
+            });
+
+            result.current.onCellChange(null, 'Zoe', 'name');
+        });
+
+        const updater = mockSetState.mock.calls[0][0];
+        const newState = updater({
+            editingCellData: { name: 'Alice' }
+        });
+
+        expect(newState.editingCellData).toEqual({ name: 'Alice' });
+    });
+
+    it('should handle null e and fallback to value', () => {
+        const mockSetState = jest.fn();
+
+        const { result } = setup();
+
+        act(() => {
+            result.current.configure({
+                editingCell: { baseRowIndex: 0 },
+                editingCellData: {},
+                rowsData: [{ __$index__: 0, name: 'Alice' }],
+                setState: mockSetState
+            });
+
+            result.current.onCellChange(null, 'Zoe', 'name');
+        });
+
+        const updater = mockSetState.mock.calls[0][0];
+        const newState = updater({
+            editingCellData: {}
+        });
+
+        expect(newState.rowsData[0].name).toBe('Zoe');
+    });
+
+    it('should fallback to empty object when editingCellData is undefined', () => {
+        const mockSetState = jest.fn();
+
+        const { result } = setup();
+
+        act(() => {
+            result.current.configure({
+                editingCell: { baseRowIndex: 0 },
+                rowsData: [{ __$index__: 0, name: 'Alice' }],
+                dataReceivedRef: { current: [{ name: 'Alice' }] },
+                setState: mockSetState
+            });
+
+            result.current.onCellChange(null, 'Zoe', 'name');
+        });
+
+        const updater = mockSetState.mock.calls[0][0];
+        const updatedState = updater({ editingCellData: undefined });
+
+        expect(updatedState.rowsData[0].name).toBe('Zoe');
+        expect(updatedState.editingCellData).toEqual({ name: 'Alice' });
+    });
+
+    it('should not throw when setState is default no-op', () => {
+        const cellChangedRef = { current: false };
+        const { result } = renderHook(() =>
+            useCellChange({ cellChangedRef })
+        );
+        act(() => {
+            result.current.configure({
+                editingCell: { baseRowIndex: 0 },
+                editingCellData: null,
+                rowsData: [{ __$index__: 0, name: 'Alice' }],
+                dataReceivedRef: { current: [{ name: 'Alice' }] }
+            });
+            expect(() => {
+                result.current.onCellChange(null, 'Bob', 'name');
+            }).not.toThrow();
+        });
+        expect(cellChangedRef.current).toBe(true);
+    });
+});

--- a/__tests__/src/hooks/use-cell-commit.test.js
+++ b/__tests__/src/hooks/use-cell-commit.test.js
@@ -1,0 +1,184 @@
+import { act, renderHook } from '@testing-library/react';
+import { useCellCommit } from '../../../src/hooks/use-cell-commit';
+
+describe('useCellCommit', () => {
+    it('should call onCellUpdate and reset refs when exiting and cellChangedRef is true', () => {
+        const mockSetState = jest.fn();
+        const mockOnCellUpdate = jest.fn();
+        const cellChangedRef = { current: true };
+        const cellChangedFocusRef = { current: null };
+
+        const { result } = renderHook(() =>
+            useCellCommit({ cellChangedRef, cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, columnName: 'name' },
+                setState: mockSetState,
+                onCellUpdate: mockOnCellUpdate
+            });
+
+            result.current.commitChanges(
+                [{ colName: 'name' }],
+                { name: 'Alice', __$index__: 0 },
+                true
+            );
+        });
+
+        expect(cellChangedFocusRef.current).toEqual({ rowIndex: 0, columnName: 'name' });
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        expect(mockOnCellUpdate).toHaveBeenCalledWith({
+            rowIndex: 0,
+            editedColumns: [{ colName: 'name', value: 'Alice' }],
+            updatedRow: { name: 'Alice', __$index__: 0 }
+        });
+        expect(cellChangedRef.current).toBe(false);
+    });
+
+    it('should not call onCellUpdate if not exiting', () => {
+        const mockSetState = jest.fn();
+        const mockOnCellUpdate = jest.fn();
+        const cellChangedRef = { current: true };
+        const cellChangedFocusRef = { current: null };
+
+        const { result } = renderHook(() =>
+            useCellCommit({ cellChangedRef, cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, columnName: 'name' },
+                setState: mockSetState,
+                onCellUpdate: mockOnCellUpdate
+            });
+
+            result.current.commitChanges(
+                [{ colName: 'name' }],
+                { name: 'Bob', __$index__: 1 },
+                false
+            );
+        });
+
+        expect(cellChangedFocusRef.current).toBeNull();
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        expect(mockOnCellUpdate).not.toHaveBeenCalled();
+        expect(cellChangedRef.current).toBe(true);
+    });
+
+    it('should not call onCellUpdate if cellChangedRef is false', () => {
+        const mockSetState = jest.fn();
+        const mockOnCellUpdate = jest.fn();
+        const cellChangedRef = { current: false };
+        const cellChangedFocusRef = { current: null };
+
+        const { result } = renderHook(() =>
+            useCellCommit({ cellChangedRef, cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 1, columnName: 'age' },
+                setState: mockSetState,
+                onCellUpdate: mockOnCellUpdate
+            });
+
+            result.current.commitChanges(
+                [{ colName: 'age' }],
+                { age: 28, __$index__: 1 },
+                true
+            );
+        });
+
+        expect(mockOnCellUpdate).not.toHaveBeenCalled();
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw if onCellUpdate is not a function', () => {
+        const mockSetState = jest.fn();
+        const cellChangedRef = { current: true };
+        const cellChangedFocusRef = { current: null };
+
+        const { result } = renderHook(() =>
+            useCellCommit({ cellChangedRef, cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 2, columnName: 'id' },
+                setState: mockSetState,
+                onCellUpdate: null
+            });
+
+            expect(() =>
+                result.current.commitChanges(
+                    [{ colName: 'id' }],
+                    { id: 123, __$index__: 2 },
+                    true
+                )
+            ).not.toThrow();
+        });
+
+        expect(mockSetState).toHaveBeenCalled();
+    });
+
+    it('should use default no-op setState if not configured', () => {
+        const cellChangedRef = { current: true };
+        const cellChangedFocusRef = { current: null };
+
+        const { result } = renderHook(() =>
+            useCellCommit({ cellChangedRef, cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, columnName: 'name' }
+            });
+
+            expect(() =>
+                result.current.commitChanges(
+                    [{ colName: 'name' }],
+                    { name: 'Fallback', __$index__: 0 },
+                    true
+                )
+            ).not.toThrow();
+        });
+        expect(cellChangedFocusRef.current).toEqual({ rowIndex: 0, columnName: 'name' });
+    });
+
+    it('should retain prev.editingCell and prev.editingCellData when not exiting', () => {
+        const cellChangedRef = { current: true };
+        const cellChangedFocusRef = { current: null };
+
+        const mockSetState = jest.fn();
+        const prevState = {
+            editingCell: { rowIndex: 1, columnName: 'name' },
+            editingCellData: { name: 'Bob' }
+        };
+
+        const { result } = renderHook(() =>
+            useCellCommit({ cellChangedRef, cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                setState: mockSetState,
+                editingCell: prevState.editingCell,
+                onCellUpdate: jest.fn()
+            });
+
+            result.current.commitChanges(
+                [{ colName: 'name' }],
+                { name: 'Bob', __$index__: 1 },
+                false
+            );
+        });
+
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        const updater = mockSetState.mock.calls[0][0];
+        const newState = updater(prevState);
+
+        expect(newState.editingCell).toEqual(prevState.editingCell);
+        expect(newState.editingCellData).toEqual(prevState.editingCellData);
+    });
+});

--- a/__tests__/src/hooks/use-cell-revert.test.js
+++ b/__tests__/src/hooks/use-cell-revert.test.js
@@ -1,0 +1,294 @@
+import { act, renderHook } from '@testing-library/react';
+import { useCellRevert } from '../../../src/hooks/use-cell-revert';
+
+describe('useCellRevert', () => {
+    let cellChangedFocusRef;
+
+    beforeEach(() => {
+        cellChangedFocusRef = { current: null };
+    });
+
+    it('should revert changes correctly and update state', () => {
+        const mockSetState = jest.fn();
+        const dataReceivedRef = {
+            current: [
+                { name: 'Alice', age: 25, __$index__: 0 }
+            ]
+        };
+
+        const initialRow = {
+            name: 'Bob',
+            age: 30,
+            __$index__: 0
+        };
+
+        const editableColumns = [
+            { colName: 'name' },
+            { colName: 'age' }
+        ];
+
+        const { result } = renderHook(() =>
+            useCellRevert({ cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, baseRowIndex: 0 },
+                editingCellData: { name: 'Alice', age: 25 },
+                rowsData: [initialRow],
+                setState: mockSetState,
+                dataReceivedRef
+            });
+
+            result.current.revertChanges(editableColumns);
+        });
+        expect(cellChangedFocusRef.current).toEqual({ rowIndex: 0, baseRowIndex: 0 });
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        const newState = mockSetState.mock.calls[0][0]({});
+
+        expect(newState.rowsData[0]).toEqual({ name: 'Alice', age: 25, __$index__: 0 });
+        expect(newState.editingCell).toBeNull();
+        expect(newState.editingCellData).toBeNull();
+        expect(dataReceivedRef.current[0]).toEqual({ name: 'Alice', age: 25, __$index__: 0 });
+    });
+
+    it('should do nothing if row index is not found', () => {
+        const mockSetState = jest.fn();
+
+        const { result } = renderHook(() =>
+            useCellRevert({ cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, baseRowIndex: 99 },
+                editingCellData: { name: 'Alice' },
+                rowsData: [{ name: 'Bob', __$index__: 0 }],
+                setState: mockSetState,
+                dataReceivedRef: { current: [] }
+            });
+
+            result.current.revertChanges([{ colName: 'name' }]);
+        });
+
+        expect(mockSetState).not.toHaveBeenCalled();
+        expect(cellChangedFocusRef.current).toEqual({ rowIndex: 0, baseRowIndex: 99 });
+    });
+
+    it('should skip reverting if editableColumns is empty', () => {
+        const mockSetState = jest.fn();
+
+        const { result } = renderHook(() =>
+            useCellRevert({ cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, baseRowIndex: 0 },
+                editingCellData: { name: 'Alice' },
+                rowsData: [{ name: 'Bob', __$index__: 0 }],
+                setState: mockSetState,
+                dataReceivedRef: { current: [] }
+            });
+
+            result.current.revertChanges([]);
+        });
+
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        const newState = mockSetState.mock.calls[0][0]({});
+        expect(newState.rowsData[0].name).toBe('Bob');
+    });
+
+    it('should skip updating dataReceivedRef if fullDataRow is falsy', () => {
+        const mockSetState = jest.fn();
+        const dataReceivedRef = {
+            current: [null]
+        };
+
+        const initialRow = {
+            name: 'Bob',
+            age: 30,
+            __$index__: 0
+        };
+
+        const editableColumns = [
+            { colName: 'name' }
+        ];
+
+        const { result } = renderHook(() =>
+            useCellRevert({ cellChangedFocusRef: { current: null } })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, baseRowIndex: 0 },
+                editingCellData: { name: 'Alice' },
+                rowsData: [initialRow],
+                setState: mockSetState,
+                dataReceivedRef
+            });
+
+            result.current.revertChanges(editableColumns);
+        });
+
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        const newState = mockSetState.mock.calls[0][0]({});
+        expect(newState.rowsData[0].name).toBe('Alice');
+        expect(dataReceivedRef.current[0]).toBeNull();
+    });
+
+    it('should skip updating dataReceivedRef if dataReceivedRef.current is not an array', () => {
+        const mockSetState = jest.fn();
+        const dataReceivedRef = {
+            current: {}
+        };
+
+        const initialRow = {
+            name: 'Bob',
+            age: 30,
+            __$index__: 0
+        };
+
+        const editableColumns = [
+            { colName: 'name' }
+        ];
+
+        const cellChangedFocusRef = { current: null };
+
+        const { result } = renderHook(() =>
+            useCellRevert({ cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, baseRowIndex: 0 },
+                editingCellData: { name: 'Alice' },
+                rowsData: [initialRow],
+                setState: mockSetState,
+                dataReceivedRef
+            });
+
+            result.current.revertChanges(editableColumns);
+        });
+
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        const updatedState = mockSetState.mock.calls[0][0]({});
+        expect(updatedState.rowsData[0].name).toBe('Alice');
+        expect(dataReceivedRef.current).toEqual({});
+    });
+
+    it('should skip reverting column if editingCellData does not contain the column', () => {
+        const mockSetState = jest.fn();
+        const dataReceivedRef = {
+            current: [{ name: 'ShouldNotChange', age: 25 }]
+        };
+
+        const initialRow = {
+            name: 'Bob',
+            age: 30,
+            __$index__: 0
+        };
+
+        const editableColumns = [
+            { colName: 'name' },
+            { colName: 'age' }
+        ];
+
+        const cellChangedFocusRef = { current: null };
+
+        const { result } = renderHook(() =>
+            useCellRevert({ cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, baseRowIndex: 0 },
+                editingCellData: {
+                    age: 24
+                },
+                rowsData: [initialRow],
+                setState: mockSetState,
+                dataReceivedRef
+            });
+
+            result.current.revertChanges(editableColumns);
+        });
+
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        const newState = mockSetState.mock.calls[0][0]({});
+        expect(newState.rowsData[0].name).toBe('Bob');
+        expect(newState.rowsData[0].age).toBe(24);
+        expect(dataReceivedRef.current[0]).toEqual({ name: 'ShouldNotChange', age: 24 });
+    });
+
+    it('should skip setting focus ref if cellChangedFocusRef is not provided', () => {
+        const mockSetState = jest.fn();
+        const dataReceivedRef = {
+            current: [{ name: 'Bob', age: 30 }]
+        };
+
+        const initialRow = {
+            name: 'Bob',
+            age: 30,
+            __$index__: 0
+        };
+
+        const editableColumns = [
+            { colName: 'name' }
+        ];
+
+        const { result } = renderHook(() =>
+            useCellRevert({ cellChangedFocusRef: undefined })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, baseRowIndex: 0 },
+                editingCellData: { name: 'Alice' },
+                rowsData: [initialRow],
+                setState: mockSetState,
+                dataReceivedRef
+            });
+
+            result.current.revertChanges(editableColumns);
+        });
+
+        expect(mockSetState).toHaveBeenCalledTimes(1);
+        const updatedState = mockSetState.mock.calls[0][0]({});
+        expect(updatedState.rowsData[0].name).toBe('Alice');
+    });
+
+    it('should safely use default no-op setState if not provided', () => {
+        const dataReceivedRef = {
+            current: [{ name: 'Bob', age: 30 }]
+        };
+
+        const initialRow = {
+            name: 'Bob',
+            age: 30,
+            __$index__: 0
+        };
+
+        const editableColumns = [{ colName: 'name' }];
+        const cellChangedFocusRef = { current: null };
+        const { result } = renderHook(() =>
+            useCellRevert({ cellChangedFocusRef })
+        );
+
+        act(() => {
+            result.current.configure({
+                editingCell: { rowIndex: 0, baseRowIndex: 0 },
+                editingCellData: { name: 'Alice' },
+                rowsData: [initialRow],
+                dataReceivedRef
+            });
+            result.current.revertChanges(editableColumns);
+        });
+
+        expect(dataReceivedRef.current[0].name).toBe('Alice');
+        expect(cellChangedFocusRef.current).toEqual({
+            rowIndex: 0,
+            baseRowIndex: 0
+        });
+    });
+});

--- a/__tests__/src/hooks/use-field-navigation.test.js
+++ b/__tests__/src/hooks/use-field-navigation.test.js
@@ -39,7 +39,6 @@ describe('useFieldNavigation', () => {
             });
 
             expect(baseParams.commitChanges).toHaveBeenCalledWith(
-                baseParams.rowIndex,
                 baseParams.editableColumns,
                 baseParams.baseRow,
                 false
@@ -64,7 +63,6 @@ describe('useFieldNavigation', () => {
             });
 
             expect(baseParams.commitChanges).toHaveBeenCalledWith(
-                baseParams.rowIndex,
                 baseParams.editableColumns,
                 baseParams.baseRow,
                 false
@@ -104,7 +102,6 @@ describe('useFieldNavigation', () => {
                 jest.runAllTimers();
             });
             expect(paramsFirst.commitChanges).toHaveBeenCalledWith(
-                paramsFirst.rowIndex,
                 paramsFirst.editableColumns,
                 paramsFirst.baseRow,
                 true
@@ -117,7 +114,6 @@ describe('useFieldNavigation', () => {
                 jest.runAllTimers();
             });
             expect(paramsLast.commitChanges).toHaveBeenCalledWith(
-                paramsLast.rowIndex,
                 paramsLast.editableColumns,
                 paramsLast.baseRow,
                 true
@@ -144,7 +140,6 @@ describe('useFieldNavigation', () => {
             expect(baseParams.isNavigatingRef.current).toBe(true);
             expect(baseParams.focusInput).toHaveBeenCalledWith(2);
             expect(baseParams.commitChanges).toHaveBeenCalledWith(
-                baseParams.rowIndex,
                 baseParams.editableColumns,
                 baseParams.baseRow,
                 false
@@ -173,7 +168,6 @@ describe('useFieldNavigation', () => {
             expect(baseParams.isNavigatingRef.current).toBe(true);
             expect(baseParams.focusInput).toHaveBeenCalled();
             expect(baseParams.commitChanges).toHaveBeenCalledWith(
-                baseParams.rowIndex,
                 baseParams.editableColumns,
                 baseParams.baseRow,
                 false

--- a/__tests__/src/hooks/use-table-cell-navigation.test.js
+++ b/__tests__/src/hooks/use-table-cell-navigation.test.js
@@ -84,10 +84,11 @@ describe('useTableCellNavigation', () => {
                 rowIndex: 0,
                 col: { name: 'col1' },
                 onCellEdit: mockOnCellEdit,
+                baseRowIndex:0
             });
 
             expect(e.preventDefault).toHaveBeenCalled();
-            expect(mockOnCellEdit).toHaveBeenCalledWith('col1', 0);
+            expect(mockOnCellEdit).toHaveBeenCalledWith('col1', 0, 0);
         });
     });
 

--- a/__tests__/src/utils/component-utils.test.js
+++ b/__tests__/src/utils/component-utils.test.js
@@ -22,7 +22,7 @@ jest.mock('../../../src/helpers/format', () => ({
 
 import * as helpers from '../../../src/helpers/format';
 import * as common from './../../../src/helpers/common';
-import { calculateColumnWidth, formatRowData } from './../../../src/utils/component-utils';
+import { calculateColumnWidth, formatRowData, getNormalizedCombinedValue } from './../../../src/utils/component-utils';
 
 describe('calculateColumnWidth', () => {
     beforeEach(() => {
@@ -197,3 +197,59 @@ describe('formatRowData', () => {
     });
 });
 
+describe('getNormalizedCombinedValue', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const obj = {
+        a: '  valueA ',
+        b: 'valueB',
+        c: null,
+        d: 'valueD',
+    };
+
+    it('formats values if type matches formatType', () => {
+        const keys = ['a', 'b', 'd'];
+        const formatType = [];
+        const type = 'TEXT';
+        const format = 'someFormat';
+
+        const result = getNormalizedCombinedValue(obj, keys, formatType, type, format);
+        expect(result).toBe('  valuea  valueb valued');
+    });
+
+    it('does not format values if type not in formatType', () => {
+        const keys = ['a', 'b', 'd'];
+        const formatType = ['number'];
+        const type = 'text';
+        const format = 'someFormat';
+
+        const result = getNormalizedCombinedValue(obj, keys, formatType, type, format);
+        expect(result).toBe('  valuea  valueb valued');
+    });
+
+    it('filters out null or undefined values', () => {
+        const keys = ['a', 'c', 'd'];
+        const formatType = [];
+        const type = '';
+        const format = '';
+
+        const result = getNormalizedCombinedValue(obj, keys, formatType, type, format);
+
+        expect(result).toContain('valuea');
+        expect(result).toContain('valued');
+        expect(result).not.toContain('null');
+    });
+
+    it('uses custom separator if provided', () => {
+        const keys = ['a', 'b'];
+        const formatType = [];
+        const type = '';
+        const format = '';
+        const separator = ', ';
+
+        const result = getNormalizedCombinedValue(obj, keys, formatType, type, format, separator);
+        expect(result).toBe('  valuea , valueb');
+    });
+});

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-data-grid-lite": "1.1.6",
+    "react-data-grid-lite": "1.1.7",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.6.2"
   },

--- a/src/components/events/event-grid-search-clicked.js
+++ b/src/components/events/event-grid-search-clicked.js
@@ -70,7 +70,7 @@ export const eventGridSearchClicked = (
                             : val?.toString()?.toLowerCase();
                     }
 
-                    return terms.every(term => combinedValue.includes(term));
+                    return terms.every(term => combinedValue?.includes(term));
                 });
                 globalSearchData = [...globalSearchData, ...colObjSearchData];
             });

--- a/src/components/events/event-grid-search-clicked.js
+++ b/src/components/events/event-grid-search-clicked.js
@@ -1,5 +1,7 @@
-import { isEqual, isNull } from '../../helpers/common';
+import { Formatting_Types } from '../../constants';
+import { isEqual, isNull, normalize } from '../../helpers/common';
 import { format as formatVal } from '../../helpers/format';
+import { getNormalizedCombinedValue } from '../../utils/component-utils';
 
 /*
  * Handles column or global search logic in a grid.
@@ -17,59 +19,98 @@ export const eventGridSearchClicked = (
     state,
     setState
 ) => {
-    // Basic safety checks
     if (!e || typeof colName !== 'string') {
         return;
     }
-    const searchQuery = e.target.value;
+
+    const searchQuery = e.target.value.trim().toLowerCase();
     const format = !isNull(formatting?.format) ? formatting.format : '';
     const type = !isNull(formatting?.type) ? formatting.type : '';
     const colObj = !isNull(colObject) ? colObject : [colName];
+    const colSep = state?.columns?.
+        find(c => c?.name?.toLowerCase() === colName?.toLowerCase())?.
+        concatColumns?.separator || ' ';
+
     let data = dataReceivedRef?.current ?? [];
+
     // Update searchColsRef list
     searchColsRef.current = searchColsRef?.current?.filter(x => x.colName !== colName) ?? [];
     if (searchQuery !== '') {
-        searchColsRef.current.push({ colName, searchQuery, colObj, formatting: { format, type } });
+        searchColsRef.current.push({ colName, searchQuery, colObj, formatting: { format, type }, colSep });
     }
+
     let globalSearchData = [];
-    const formattingType = ['date', 'number', 'currency', 'percent', 'boolean'];
     searchColsRef?.current?.forEach(col => {
-        const q = col?.searchQuery?.toLowerCase(),
-            matchesSearch = (val) => !isNull(val) && val.toString().toLowerCase().includes(q);
+        const q = col?.searchQuery?.toLowerCase();
+        const terms = normalize(q).match(/\S+/g) || [];
+        const colMatchesSearch = (val) => {
+            if (isNull(val)) return false;
+            const normalizedValue = normalize(val);
+            return terms.every(term => normalizedValue.includes(term));
+        };
+
         if (col.colName === '##globalSearch##') {
             col.colObj.forEach(c => {
+                if (c?.hidden === true) return;
                 let colObjSearchData = [];
-                const hidden = c?.hidden === true, f = c?.formatting?.format ?? '',
-                    t = (c?.formatting?.type || '')?.toLowerCase(), cc = c?.concatColumns?.columns;
-                colObjSearchData = data.filter(o => formattingType?.includes(t) ?
-                    (cc ? Object.keys(o).some(k => cc.some(x => x?.toLowerCase() === k?.toLowerCase()) &&
-                        !hidden && !isNull(o[k]) && formatVal(o[k], t, f)?.toString()?.toLowerCase()?.includes(q))
-                        : !hidden && formatVal(o[c.name], t, f)?.toString()?.toLowerCase()?.includes(q))
-                    : (cc ? Object.keys(o).some(k => cc.some(x => x?.toLowerCase() === k?.toLowerCase())
-                        && !hidden && matchesSearch(o[k]))
-                        : !hidden && matchesSearch(o[c.name])));
+                const f = c?.formatting?.format ?? '';
+                const t = (c?.formatting?.type || '')?.toLowerCase();
+                const cc = c?.concatColumns?.columns;
+                const ccs = c?.concatColumns?.separator || ' ';
+
+                colObjSearchData = data.filter(o => {
+                    let combinedValue = '';
+                    // If this is a "concatenated column"
+                    if (cc && Array.isArray(cc)) {
+                        combinedValue = getNormalizedCombinedValue(o, cc, Formatting_Types, t, f, ccs);
+                    } else {
+                        const val = o[c.name];
+                        combinedValue = Formatting_Types.includes(t)
+                            ? formatVal(val, t, f)?.toString()?.toLowerCase()
+                            : val?.toString()?.toLowerCase();
+                    }
+
+                    return terms.every(term => combinedValue.includes(term));
+                });
                 globalSearchData = [...globalSearchData, ...colObjSearchData];
             });
+
             data = globalSearchData.filter((item, index, self) =>
                 index === self.findIndex(other => isEqual(item, other))
             );
         } else {
-            const t = (col?.formatting?.type || '').toLowerCase(), f = col?.formatting?.format ?? '';
-            data = data.filter(o => formattingType?.includes(t)
-                ? Object.keys(o).some(k => col.colObj.some(x => x?.toLowerCase() === k?.toLowerCase()) && !isNull(o[k])
-                    && formatVal(o[k], t, f)?.toString()?.toLowerCase()?.includes(q))
-                : Object.keys(o).some(k => col.colObj.some(x => x?.toLowerCase() === k?.toLowerCase()) && matchesSearch(o[k]))
-            );
+            const t = (col?.formatting?.type || '').toLowerCase();
+            const f = col?.formatting?.format ?? '';
+            const ccs = col?.colSep || ' ';
+
+            data = data.filter(o => {
+                // If this is a "concatenated column"
+                if (col.colObj.length > 1) {
+                    const combinedValue = getNormalizedCombinedValue(o, col.colObj, Formatting_Types, t, f, ccs);
+                    return terms.every(term => combinedValue.includes(term));
+                } else {
+                    // Single field
+                    return Object.keys(o).some(k =>
+                        col.colObj.some(x => x?.toLowerCase() === k?.toLowerCase()) &&
+                        (
+                            Formatting_Types.includes(t)
+                                ? (!isNull(o[k]) && colMatchesSearch(formatVal(o[k], t, f)))
+                                : colMatchesSearch(o[k])
+                        )
+                    );
+                }
+            });
         }
     });
+
     const dataLength = data.length;
-    setState(prev => (
-        {
-            ...prev,
-            rowsData: data,
-            activePage: 1,
-            totalRows: dataLength,
-            firstRow: 0,
-            toggleState: !state.toggleState
-        }));
+
+    setState(prev => ({
+        ...prev,
+        rowsData: data,
+        activePage: 1,
+        totalRows: dataLength,
+        firstRow: 0,
+        toggleState: !state.toggleState
+    }));
 };

--- a/src/components/grid-edit/editable-cell-fields.jsx
+++ b/src/components/grid-edit/editable-cell-fields.jsx
@@ -9,8 +9,7 @@ const EditableCellFields = memo(function EditableCellFields({
     commitChanges,
     editableColumns,
     onCellChange,
-    revertChanges,
-    rowIndex
+    revertChanges
 }) {
     const inputRefs = useRef([]);
     const isNavigatingRef = useRef(false);
@@ -34,7 +33,6 @@ const EditableCellFields = memo(function EditableCellFields({
             onChange: onCellChange,
             autoFocus: isFirstField,
             inputRef: (el) => (inputRefs.current[i] = el),
-            rowIndex,
             editableColumns,
             baseRow,
             focusInput,

--- a/src/components/grid-edit/editable-dropdown-field.jsx
+++ b/src/components/grid-edit/editable-dropdown-field.jsx
@@ -9,7 +9,6 @@ const EditableDropdownField = ({
     onChange,
     autoFocus,
     inputRef,
-    rowIndex,
     editableColumns,
     baseRow,
     focusInput,
@@ -26,7 +25,6 @@ const EditableDropdownField = ({
     const { handleBlur, handleKeyDown: fieldKeyDown, handleClick } = useFieldNavigation({
         fieldIndex,
         editableColumns,
-        rowIndex,
         baseRow,
         commitChanges,
         revertChanges,
@@ -57,7 +55,7 @@ const EditableDropdownField = ({
             const isExiting =
                 (!shiftKey && fieldIndex === editableColumns.length - 1) ||
                 (shiftKey && fieldIndex === 0);
-            commitChanges(rowIndex, editableColumns, baseRow, isExiting);
+            commitChanges(editableColumns, baseRow, isExiting);
         }
     };
 

--- a/src/components/grid-edit/editable-text-field.jsx
+++ b/src/components/grid-edit/editable-text-field.jsx
@@ -9,7 +9,6 @@ const EditableTextField = ({
     onChange,
     autoFocus,
     inputRef,
-    rowIndex,
     editableColumns,
     baseRow,
     focusInput,
@@ -29,7 +28,6 @@ const EditableTextField = ({
     } = useFieldNavigation({
         fieldIndex,
         editableColumns,
-        rowIndex,
         baseRow,
         commitChanges,
         revertChanges,

--- a/src/components/grid-rows.jsx
+++ b/src/components/grid-rows.jsx
@@ -118,7 +118,7 @@ const GridRows = ({
             ...originalRow,
             [colName]: newValue
         };
-        if (Array.isArray(dataReceivedRef.current)) {
+        if (Array.isArray(dataReceivedRef?.current)) {
             const fullDataRow = dataReceivedRef.current[baseRowIndex];
             if (fullDataRow) {
                 fullDataRow[colName] = newValue;
@@ -176,7 +176,7 @@ const GridRows = ({
             if (editingCellData?.hasOwnProperty(colName)) {
                 const originalValue = editingCellData[colName];
                 updatedRow[colName] = originalValue;
-                if (Array.isArray(dataReceivedRef.current)) {
+                if (Array.isArray(dataReceivedRef?.current)) {
                     const fullDataRow = dataReceivedRef.current[baseRowIndex];
                     if (fullDataRow) {
                         fullDataRow[colName] = originalValue;

--- a/src/components/grid-table.jsx
+++ b/src/components/grid-table.jsx
@@ -11,7 +11,8 @@ const GridTable = ({
     onSearchClicked,
     gridHeaderRef,
     computedColumnWidthsRef,
-    isResizingRef
+    isResizingRef,
+    dataReceivedRef
 }) => {
     const tableRef = useRef(null);
     useResizableTableColumns(tableRef, state, setState,
@@ -32,6 +33,7 @@ const GridTable = ({
                     state={state}
                     setState={setState}
                     computedColumnWidthsRef={computedColumnWidthsRef}
+                    dataReceivedRef={dataReceivedRef}
                 />
             </tbody>
         </table>

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,3 +13,4 @@ export const Export_To_CSV_Text = 'Export CSV';
 export const Border_Padding_Margin_Width = "1";
 export const Loader_Identifier = "table-loader-overlay";
 export const Movement_Threshold = 10; // in pixels
+export const Formatting_Types = ['date', 'number', 'currency', 'percent', 'boolean'];

--- a/src/css/react-data-grid-lite.css
+++ b/src/css/react-data-grid-lite.css
@@ -1,6 +1,6 @@
 .r-d-g-lt-comp {
     padding: 8px;
-    background-color: #e0e0e0;
+    background-color: #f5f1f1;
     border-radius: 10px;
     color: #667;
     position: relative;
@@ -64,7 +64,6 @@
         border-radius: 6px !important;
         height: 32px;
         padding: 0;
-        background-color: #e0e0e0;
         cursor: pointer;
         border: 1.5px solid #667;
         font-weight: 600 !important;
@@ -109,7 +108,7 @@
     }
 
         .r-d-g-lt-comp .dropdown-option:hover {
-            background-color: #e0e0e0;
+            background-color: #f5f1f1;
         }
 
         .r-d-g-lt-comp .dropdown-option.selected {
@@ -213,7 +212,7 @@
     }
 
 .r-d-g-lt-comp .grid-icon-div {
-    background: linear-gradient(180deg, #fff, #e0e0e0) !important;
+    background: linear-gradient(180deg, #fff, #f5f1f1) !important;
     margin: auto !important;
 }
 
@@ -382,7 +381,7 @@
 
     .r-d-g-lt-comp .react-data-grid-lite table.gd-tbl::-webkit-scrollbar-thumb:hover,
     .r-d-g-lt-comp .dropdown-options::-webkit-scrollbar-thumb:hover {
-        background-color: #e0e0e0;
+        background-color: #f5f1f1;
     }
 
 .r-d-g-lt-comp .react-data-grid-lite thead {
@@ -489,6 +488,10 @@
     border: none !important;
     border-bottom: 2px solid #e0e0e0 !important;
 }
+
+    .r-d-g-lt-comp table tbody tr.gridRow:first-child {
+        border-top: 2px solid #e0e0e0 !important;
+    }
 
     .r-d-g-lt-comp table tbody tr.gridRow td {
         border: none !important;
@@ -609,7 +612,7 @@
     }
 
         .r-d-g-lt-comp .pagination li.page-item a:hover {
-            background: #e0e0e0 !important;
+            background: #f5f1f1 !important;
             color: #fff !important;
         }
 

--- a/src/css/react-data-grid-lite.css
+++ b/src/css/react-data-grid-lite.css
@@ -192,7 +192,7 @@
 }
 
 .r-d-g-lt-comp .icon-div {
-    border-radius: 4px;
+    border-radius: 8px;
     box-shadow: 0 0 0 1.6px #667;
     height: 28px;
     letter-spacing: .001em;
@@ -219,7 +219,7 @@
 
 .r-d-g-lt-comp .clear-icon-div {
     float: left;
-    width: 50px;
+    width: 44px;
     position: relative;
     top: 0px;
     height: 40px;

--- a/src/helpers/common.js
+++ b/src/helpers/common.js
@@ -131,3 +131,10 @@ export const capitalize = (str) => {
     if (typeof str !== 'string' || !str) return '';
     return str.charAt(0).toUpperCase() + str.slice(1);
 };
+
+export const normalize = (str) =>
+    str
+        ?.toString()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase();

--- a/src/hooks/use-cell-change.js
+++ b/src/hooks/use-cell-change.js
@@ -1,0 +1,67 @@
+import { useRef } from 'react';
+
+export function useCellChange({ cellChangedRef }) {
+    const contextRef = useRef({
+        editingCell: null,
+        editingCellData: null,
+        rowsData: [],
+        dataReceivedRef: null,
+        setState: () => { }
+    });
+
+    const configure = (ctx) => {
+        contextRef.current = { ...contextRef.current, ...ctx };
+    };
+
+    const onCellChange = (e, value, colName) => {
+        const {
+            editingCell,
+            editingCellData,
+            rowsData,
+            dataReceivedRef,
+            setState
+        } = contextRef.current;
+
+        const updatedData = [...rowsData];
+        const baseRowIndex = editingCell?.baseRowIndex;
+        const newValue = e?.target?.value ?? value;
+        const rowIndexInPartial = updatedData.findIndex(row => row.__$index__ === baseRowIndex);
+
+        if (rowIndexInPartial === -1) return;
+
+        const originalRow = updatedData[rowIndexInPartial];
+        const originalValue = originalRow[colName];
+        const prevEditingData = editingCellData || {};
+        const alreadySaved = Object.prototype.hasOwnProperty.call(prevEditingData, colName);
+
+        updatedData[rowIndexInPartial] = {
+            ...originalRow,
+            [colName]: newValue
+        };
+
+        if (Array.isArray(dataReceivedRef?.current)) {
+            const fullDataRow = dataReceivedRef.current[baseRowIndex];
+            if (fullDataRow) {
+                fullDataRow[colName] = newValue;
+            }
+        }
+
+        setState(prev => ({
+            ...prev,
+            rowsData: updatedData,
+            editingCellData: alreadySaved
+                ? prev.editingCellData
+                : {
+                    ...prev.editingCellData,
+                    [colName]: originalValue
+                }
+        }));
+
+        cellChangedRef.current = true;
+    };
+
+    return {
+        onCellChange,
+        configure
+    };
+}

--- a/src/hooks/use-cell-commit.js
+++ b/src/hooks/use-cell-commit.js
@@ -1,0 +1,51 @@
+import { useRef } from 'react';
+
+export function useCellCommit({ cellChangedRef, cellChangedFocusRef }) {
+    const contextRef = useRef({
+        editingCell: null,
+        onCellUpdate: null,
+        setState: () => { }
+    });
+
+    const configure = (ctx) => {
+        contextRef.current = { ...contextRef.current, ...ctx };
+    };
+
+    const commitChanges = (editedColumns, updatedRow, isExiting) => {
+        const {
+            editingCell,
+            onCellUpdate,
+            setState
+        } = contextRef.current;
+
+        const rowIndex = updatedRow?.__$index__;
+        const exiting = isExiting === true;
+
+        cellChangedFocusRef.current = exiting ? editingCell : null;
+
+        setState(prev => ({
+            ...prev,
+            editingCell: exiting ? null : prev.editingCell,
+            editingCellData: exiting ? null : prev.editingCellData,
+        }));
+
+        const shouldFireCellUpdate = exiting && cellChangedRef.current;
+
+        if (shouldFireCellUpdate && typeof onCellUpdate === 'function') {
+            onCellUpdate({
+                rowIndex,
+                editedColumns: editedColumns.map(({ colName }) => ({
+                    colName,
+                    value: updatedRow[colName]
+                })),
+                updatedRow
+            });
+            cellChangedRef.current = false;
+        }
+    };
+
+    return {
+        commitChanges,
+        configure
+    };
+}

--- a/src/hooks/use-cell-revert.js
+++ b/src/hooks/use-cell-revert.js
@@ -1,0 +1,61 @@
+/* eslint-disable no-prototype-builtins */
+import { useRef } from 'react';
+
+export function useCellRevert({ cellChangedFocusRef }) {
+    const contextRef = useRef({
+        editingCell: null,
+        editingCellData: null,
+        rowsData: [],
+        setState: () => { },
+        dataReceivedRef: null
+    });
+
+    const configure = (ctx) => {
+        contextRef.current = { ...contextRef.current, ...ctx };
+    };
+
+    const revertChanges = (editableColumns) => {
+        const {
+            editingCell,
+            editingCellData,
+            rowsData,
+            setState,
+            dataReceivedRef
+        } = contextRef.current;
+
+        const updatedData = [...rowsData];
+        const baseRowIndex = editingCell?.baseRowIndex;
+        const rowIndexInPartial = updatedData.findIndex(row => row.__$index__ === baseRowIndex);
+        if (cellChangedFocusRef) {
+            cellChangedFocusRef.current = editingCell;
+        }
+
+        if (rowIndexInPartial === -1) return;
+
+        const updatedRow = { ...updatedData[rowIndexInPartial] };
+        editableColumns.forEach(({ colName }) => {
+            if (editingCellData?.hasOwnProperty(colName)) {
+                const originalValue = editingCellData[colName];
+                updatedRow[colName] = originalValue;
+
+                if (Array.isArray(dataReceivedRef?.current)) {
+                    const fullDataRow = dataReceivedRef.current[baseRowIndex];
+                    if (fullDataRow) {
+                        fullDataRow[colName] = originalValue;
+                    }
+                }
+            }
+        });
+
+        updatedData[rowIndexInPartial] = updatedRow;
+
+        setState(prev => ({
+            ...prev,
+            editingCell: null,
+            editingCellData: null,
+            rowsData: updatedData
+        }));
+    };
+
+    return { revertChanges, configure };
+}

--- a/src/hooks/use-field-navigation.js
+++ b/src/hooks/use-field-navigation.js
@@ -1,7 +1,6 @@
 export function useFieldNavigation({
     fieldIndex,
     editableColumns,
-    rowIndex,
     baseRow,
     commitChanges,
     revertChanges,
@@ -22,7 +21,7 @@ export function useFieldNavigation({
             if (!isStillInsideCell) {
                 const isExiting =
                     fieldIndex === editableColumns.length - 1 || fieldIndex === 0;
-                commitChanges(rowIndex, editableColumns, baseRow, isExiting);
+                commitChanges(editableColumns, baseRow, isExiting);
                 if (isNavigatingRef)
                     isNavigatingRef.current = false;
                 if (preventBlurRef)
@@ -52,7 +51,7 @@ export function useFieldNavigation({
                 (!shiftKey && fieldIndex === editableColumns.length - 1) ||
                 (shiftKey && fieldIndex === 0);
 
-            commitChanges(rowIndex, editableColumns, baseRow, isExiting);
+            commitChanges(editableColumns, baseRow, isExiting);
         } else if (key === 'Escape') {
             e.preventDefault();
             revertChanges(editableColumns);

--- a/src/hooks/use-table-cell-navigation.js
+++ b/src/hooks/use-table-cell-navigation.js
@@ -1,6 +1,6 @@
 export function useTableCellNavigation() {
     return function onKeyDown(e,
-        { editable, editingCell, rowIndex, col, columns, onCellEdit }) {
+        { editable, editingCell, rowIndex, col, columns, onCellEdit, baseRowIndex }) {
         if (!editable) return;
 
         const isEditing =
@@ -14,14 +14,16 @@ export function useTableCellNavigation() {
 
         switch (e.key) {
             case 'Enter':
-                const interactiveTags = ['A', 'BUTTON', 'INPUT', 'TEXTAREA', 'SELECT'];
-                const activeEl = document.activeElement;
-                if (activeEl && interactiveTags.includes(activeEl.tagName)) {
-                    return;
+                {
+                    const interactiveTags = ['A', 'BUTTON', 'INPUT', 'TEXTAREA', 'SELECT'];
+                    const activeEl = document.activeElement;
+                    if (activeEl && interactiveTags.includes(activeEl.tagName)) {
+                        return;
+                    }
+                    e.preventDefault();
+                    onCellEdit(currentColName, currentRow, baseRowIndex);
+                    break;
                 }
-                e.preventDefault();
-                onCellEdit(currentColName, currentRow);
-                break;
 
             case 'ArrowDown':
                 e.preventDefault();

--- a/src/react-data-grid-lite.jsx
+++ b/src/react-data-grid-lite.jsx
@@ -89,7 +89,7 @@ const DataGrid = ({
         searchValues: {},
         editingCell: null
     });
-    const dataReceivedRef = useRef(data);
+    const dataReceivedRef = useRef(null);
     const searchColsRef = useRef([]);
     const gridHeaderRef = useRef(null);
     const prevPageRef = useRef(null);
@@ -150,15 +150,20 @@ const DataGrid = ({
     }, [columns]);
 
     useEffect(() => {
-        dataReceivedRef.current = data ?? [];
-        if (!isNull(data))
+        if (!isNull(data)) {
+            const processedRows = data?.map((row, index) => ({
+                ...row,
+                __$index__: index
+            }));
+            dataReceivedRef.current = processedRows;
             setState((prevState) => ({
                 ...prevState,
-                rowsData: !isNull(data) ? data : [],
-                totalRows: data?.length,
-                pageRows: !isNull(parseInt(pageSize, 10)) ? parseInt(pageSize, 10) : data?.length,
-                currentPageRows: !isNull(parseInt(pageSize, 10)) ? parseInt(pageSize, 10) : data?.length
+                rowsData: processedRows,
+                totalRows: processedRows?.length,
+                pageRows: !isNull(parseInt(pageSize, 10)) ? parseInt(pageSize, 10) : processedRows?.length,
+                currentPageRows: !isNull(parseInt(pageSize, 10)) ? parseInt(pageSize, 10) : processedRows?.length
             }));
+        }
     }, [data]);
 
     useEffect(() => {
@@ -358,6 +363,7 @@ const DataGrid = ({
                     gridHeaderRef={gridHeaderRef}
                     computedColumnWidthsRef={computedColumnWidthsRef}
                     isResizingRef={isResizingRef}
+                    dataReceivedRef={dataReceivedRef}
                 />
             </div>
             {state.showFooter === true && (

--- a/src/utils/component-utils.js
+++ b/src/utils/component-utils.js
@@ -10,9 +10,10 @@ import {
 import {
     convertViewportUnitToPixels,
     getContainerWidthInPixels,
-    isNull
+    isNull,
+    normalize
 } from "../helpers/common";
-import { format } from "../helpers/format";
+import { format as formatVal } from "../helpers/format";
 
 export function calculateColumnWidth(
     colWidthArray,
@@ -148,9 +149,22 @@ const getConcatValue = (row, columns, concatColumns) => {
 
 const getFormattedValue = (value, formatting) => {
     if (!isNull(value) && formatting?.type) {
-        return format(value, formatting.type, formatting.format);
+        return formatVal(value, formatting.type, formatting.format);
     }
     return value;
+};
+
+export const getNormalizedCombinedValue = (obj, keys, formatType, type, format, separator = ' ') => {
+    return keys
+        .map(k => {
+            const val = obj[k];
+            return formatType.includes(type?.toLowerCase())
+                ? formatVal(val, type?.toLowerCase(), format)
+                : val;
+        })
+        .filter(v => !isNull(v))
+        .map(normalize)
+        .join(separator);
 };
 
 export const resolveColumnType = (concatType, baseType) => {


### PR DESCRIPTION
This PR introduces several key improvements and fixes to enhance the reliability, modularity, and user experience of grid cell editing and data handling:

---

### ✅ **Fixes**

* Synchronized updates between the visible grid and the full dataset by:

  * Adding a `__$index__` field to all rows in `dataReceivedRef`
  * Ensuring `onCellChange` and `revertChanges` apply changes consistently across both datasets
  * Supporting correct behavior with pagination and filtering

---

### 🧩 **Refactor: Cell Editing Logic**

* Extracted core logic into custom hooks:

  * `useCellChange`
  * `useCellCommit`
  * `useCellRevert`
* Each hook encapsulates related state and logic, improving:

  * Code modularity and readability
  * Testability (comprehensive unit tests added)
  * Flexibility via `configure()` context injection

---

### 🔍 **Search Enhancements**

* Improved search behavior:

  * Supports multi-word and special character input
  * Handles diacritics (e.g., "résumé" matches "resume")
  * Enables concatenated field searching with configurable separators
* Abstracted common formatting logic into utility functions

---

### 🎨 **UI Update**

* Changed default theme background color to `#f5f1f1` (was `#e0e0e0`) for a softer visual tone

---

### 🧪 **Test Coverage**

* Added full test coverage for:

  * New hooks and edge cases
  * Fallbacks in cell updates and grid state transitions
  * Utility functions like `normalize()` and `getNormalizedCombinedValue()`
